### PR TITLE
Fix shebang in hooks/post_gen_project.sh

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 APP_NAME="{{ cookiecutter.app_name }}"
 USE_ANALYTICS="{{ cookiecutter.firebase_analytics }}"


### PR DESCRIPTION
`hooks/post_gen_project.sh` was using Bash specific syntax but the shebang was set to `/bin/sh`