### PR TITLE
Default parameter for primary BaseFragment constructor

### DIFF
--- a/{{cookiecutter.repo_name}}/app/src/main/java/{{cookiecutter.package_name}}/base/BaseFragment.kt
+++ b/{{cookiecutter.repo_name}}/app/src/main/java/{{cookiecutter.package_name}}/base/BaseFragment.kt
@@ -1,5 +1,6 @@
 package {{ cookiecutter.package_name }}.base
 
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -10,7 +11,7 @@ import javax.inject.Inject
 /**
  * Base class to use for this application
  */
-abstract class BaseFragment : Fragment(), Injectable {
+abstract class BaseFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(contentLayoutId), Injectable {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory


### PR DESCRIPTION
The default implementation of `Fragment.onCreateView(LayoutInflator, ViewGroup, Bundle)` will try to inflate the given layout in the primary `BaseFragment` constructor if it isn't 0, meaning that there would be no need to override `onCreateView` in subclasses of `BaseFragment` if the layout is given.