### PR TITLE
Update `installKtlintGitHook` task

### DIFF
--- a/{{cookiecutter.repo_name}}/buildSrc/src/main/kotlin/at/allaboutapps/build/BuildPlugin.kt
+++ b/{{cookiecutter.repo_name}}/buildSrc/src/main/kotlin/at/allaboutapps/build/BuildPlugin.kt
@@ -66,8 +66,19 @@ class BuildPlugin : Plugin<Project> {
      */
     private fun registerKtLintCheck(project: Project) {
         project.tasks.register("installKtlintGitHook", Copy::class.java) {
+            val gitDirName = System.getenv("GIT_DIR")
+                ?.takeIf(String::isNotEmpty)
+                ?: ".git"
+
+            var gitDir = File(project.rootProject.rootDir, gitDirName)
+
+            if (gitDir.isFile) {
+                // is a worktree
+                gitDir = File(gitDir.readText().removePrefix("gitdir: ").trim(), "../..").normalize()
+            }
+
             from(File(project.rootProject.rootDir, "hooks/ktlint-git-pre-commit-hook-android.sh"))
-            into(File(project.rootProject.rootDir, ".git/hooks"))
+            into(File(gitDir, "hooks"))
             rename { "pre-commit" }
             fileMode = 493 // 493 == 0755 (octal)
         }


### PR DESCRIPTION
* Uses the `GIT_DIR` environment variable when set and not empty. If not set or empty, defaults to `.git` as expected)
* Added support for worktrees